### PR TITLE
FEAT: Detect derived data if not explicitly passed

### DIFF
--- a/scripts/integration_test_ios.sh
+++ b/scripts/integration_test_ios.sh
@@ -6,5 +6,5 @@ cd examples/ios
 bundle install
 bundle exec pod install
 
-python3 -m cicd.ios.build --derived-data-path DerivedData --build-for-testing
-python3 -m cicd.ios.test --derived-data-path DerivedData --test-without-building
+python3 -m cicd.ios.build --build-for-testing
+python3 -m cicd.ios.test --test-without-building

--- a/src/cicd/ios/mixin/metadata.py
+++ b/src/cicd/ios/mixin/metadata.py
@@ -1,0 +1,11 @@
+from cicd.ios.project.metadata import Metadata
+
+__all__ = ['MetadataMixin']
+
+_metadata = Metadata()
+
+
+class MetadataMixin:
+    @property
+    def metadata(self):
+        return _metadata

--- a/src/cicd/ios/xcodebuild/action/base.py
+++ b/src/cicd/ios/xcodebuild/action/base.py
@@ -3,15 +3,14 @@ from shlex import quote
 from typing import Optional
 
 from cicd.core.logger import logger
-from cicd.ios.project.metadata import Metadata
+from cicd.ios.mixin.metadata import MetadataMixin
 
 __all__ = ['XCBAction']
 
 
-class CmdMaker:
+class CmdMaker(MetadataMixin):
     def __init__(self, **kwargs) -> None:
         self.kwargs = kwargs
-        self.metadata = Metadata()
 
     def make(self) -> Optional[str]:
         raise NotImplementedError
@@ -91,7 +90,7 @@ class TeeCmdMaker(CmdMaker):
             return f'tee {quote(log_path)}'
 
 
-class XCBAction:
+class XCBAction(MetadataMixin):
     def run(self, **kwargs):
         makers = [
             XCBCmdMaker(**kwargs),

--- a/src/cicd/ios/xcodebuild/action/test.py
+++ b/src/cicd/ios/xcodebuild/action/test.py
@@ -40,5 +40,5 @@ class XCBTestAction(XCBAction):
             raise TestError(xcresult, e)
 
     def _derived_data_path(self, **kwargs) -> Path:
-        # TODO: Run xcodebuild -showBuildSettings to get the default data path
-        return Path(kwargs.get('derived_data_path') or 'DerivedData')
+        path = kwargs.get('derived_data_path')
+        return Path(path) if path else self.metadata.default_derived_data


### PR DESCRIPTION
DerivedData path is where we look for build products, test results, etc.

When the DerivedData path is not passed to the job, the xcodebuild process assumes the default one of the workspace/project (ex. `~/Library/Developer/Xcode/DerivedData/<Project-blah-blah>`).

In this case, we detect the DerivedData path simply by running `xcodebuild -showBuildSettings` and parsing the respective build settings.
