### PR TITLE
FEAT: centralized CLI

### DIFF
--- a/src/cicd/core/utils/cli_group.py
+++ b/src/cicd/core/utils/cli_group.py
@@ -1,0 +1,30 @@
+import functools
+import pkgutil
+
+import click
+
+__all__ = ['cli_group']
+
+
+def create_cli_group(module_name: str, target: click.Command):
+    import importlib
+
+    module = importlib.import_module(module_name)
+    for _, submodule_name, _ in pkgutil.iter_modules(module.__path__):
+        submodule = importlib.import_module(f'{module_name}.{submodule_name}')
+        if submodule_name != 'cli' and hasattr(submodule, 'cli'):
+            command = getattr(submodule, 'cli')
+            target.add_command(command, name=submodule_name)
+
+
+def cli_group(name: str):
+    def decorator(func: click.Command):
+        @functools.wraps(func)
+        @click.group()
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        create_cli_group(name, target=wrapper)
+        return wrapper
+
+    return decorator

--- a/src/cicd/ios/cli.py
+++ b/src/cicd/ios/cli.py
@@ -1,0 +1,10 @@
+from cicd.core.utils.cli_group import cli_group
+
+
+@cli_group('cicd.ios')
+def cli():
+    pass
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
Support for centralize CLI (multiple subcommands) under one package.

This way, users can run `python3 -m cicd.ios.cli --help` to see what are the available CLI for them to use.