### PR TITLE
FEAT: Handle job/action timeout

### DIFF
--- a/src/cicd/core/utils/sh.py
+++ b/src/cicd/core/utils/sh.py
@@ -1,3 +1,5 @@
+import os
+import signal
 import subprocess
 from typing import Optional
 
@@ -19,6 +21,30 @@ class Shell:
                 return proc.stdout.decode('utf-8').strip()
         except Exception as e:
             raise Shell.ExecError(e)
+
+    def popen(self, *args, **kwargs) -> subprocess.Popen:
+        return subprocess.Popen(*args, **kwargs)
+
+    def exec(self, *args, **kwargs):
+        timeout = kwargs.pop('timeout', None)
+        proc = self.popen(*args, **kwargs)
+        try:
+            output, err = proc.communicate(timeout=timeout)
+            if proc.returncode != 0:
+                raise Shell.ExecError(
+                    'Command failed with code {}: {}. Error: {}'.format(
+                        proc.returncode,
+                        args,
+                        err.decode('utf-8').strip() if err else None,
+                    )
+                )
+            return output.decode('utf-8').strip() if output else None
+        except (subprocess.TimeoutExpired, TimeoutError) as e:
+            # Clean up process group. For some long-running (shell) commands such as `xcodebuild foo | bar`,
+            # the child processes are not getting cleaned up properly.
+            # --> Kill the process group to clean up them all.
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            raise e
 
 
 sh = Shell()

--- a/src/cicd/ios/runner/base.py
+++ b/src/cicd/ios/runner/base.py
@@ -1,7 +1,20 @@
+from cicd.core.utils.timeout import timeout
+
+
 class Runner:
     def run(self, **kwargs):
-        if self.action:
+        if not self.action:
+            return
+
+        timeout_in_sec = kwargs.get('timeout')
+        if not timeout_in_sec:
             return self.action.run(**kwargs)
+
+        @timeout(timeout_in_sec)
+        def run_with_timeout():
+            return self.action.run(**kwargs)
+
+        return run_with_timeout()
 
     @property
     def action(self):

--- a/src/cicd/ios/xcodebuild/action/base.py
+++ b/src/cicd/ios/xcodebuild/action/base.py
@@ -1,8 +1,8 @@
-import subprocess
 from shlex import quote
 from typing import Optional
 
 from cicd.core.logger import logger
+from cicd.core.utils.sh import sh
 from cicd.ios.mixin.metadata import MetadataMixin
 
 __all__ = ['XCBAction']
@@ -100,4 +100,4 @@ class XCBAction(MetadataMixin):
         cmd = 'set -o pipefail && '
         cmd += ' | '.join(x for x in [maker.make() for maker in makers] if x)
         logger.info(f'$ {cmd}')
-        return subprocess.run(cmd, check=True, shell=True)
+        return sh.exec(cmd, shell=True, timeout=kwargs.get('timeout'))


### PR DESCRIPTION
Handle job/action timeout (when passing `--timeout <seconds>` to the CLI)