### PR TITLE
FEAT: Implement test retries

### DIFF
--- a/examples/ios/EX.xcodeproj/xcshareddata/xcschemes/EX.xcscheme
+++ b/examples/ios/EX.xcodeproj/xcshareddata/xcschemes/EX.xcscheme
@@ -26,7 +26,23 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0F4AE04284F283F00EDF1C1"
+            BuildableName = "EX.app"
+            BlueprintName = "EX"
+            ReferencedContainer = "container:EX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "RETRY_TRACE_PATH"
+            value = "$(PWD)/tmp/test_retries_trace"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/examples/ios/EXUITests/EXUITests.swift
+++ b/examples/ios/EXUITests/EXUITests.swift
@@ -11,4 +11,20 @@ import XCTest
 class EXUITests: XCTestCase {
   func testUI1() throws { }
   func testUI2() throws { }
+  func testUI3() throws {
+    // This logic is to simulate flaky test.
+    // The test fails in the 1st run and succeeds in the 2nd run.
+    // The attempt count is controlled by an external file (ignored by git)
+    //     $(PWD)/tmp/test_retries_trace
+    // Make sure you reset the content of this file to 0 beforehand.
+    guard let path = ProcessInfo.processInfo.environment["RETRY_TRACE_PATH"],
+          let text = try? String(contentsOfFile: path, encoding: .utf8),
+          let count = Int(text)
+    else { return }
+
+    if count < 1 {
+      try (count + 1).description.write(toFile: path, atomically: true, encoding: .utf8)
+      XCTFail("Failed on purpose (count = \(count))")
+    }
+  }
 }

--- a/scripts/integration_test_ios.sh
+++ b/scripts/integration_test_ios.sh
@@ -2,11 +2,15 @@
 set -e
 
 cd examples/ios
+mkdir -p tmp && printf 0 > tmp/test_retries_trace # To simulate test retries
 
 bundle install
 
 python3 -m cicd.ios.build \
     --cocoapods \
+    --derived-data-path DerivedData \
     --build-for-testing
 python3 -m cicd.ios.test \
+    --retries 1 \
+    --derived-data-path DerivedData \
     --test-without-building

--- a/src/cicd/ios/runner/base.py
+++ b/src/cicd/ios/runner/base.py
@@ -1,18 +1,50 @@
+from typing import Optional
+
+from retry import retry
+
+from cicd.core.logger import logger
 from cicd.core.utils.timeout import timeout
 
 
 class Runner:
+    class RetryContext(dict):
+        @property
+        def idx(self) -> int:
+            return self.get('idx', 0)
+
+        @property
+        def error(self) -> Optional[Exception]:
+            return self.get('error')
+
     def run(self, **kwargs):
+        timeout_in_sec = kwargs.get('timeout')
+        tries = (kwargs.get('retries') or 0) + 1
+        retry_kwargs_fn = kwargs.get('retry_kwargs_fn')
+        ctx = Runner.RetryContext()
+
+        @retry(tries=tries, logger=logger)
+        def run_without_timeout():
+            if callable(retry_kwargs_fn):
+                retry_kwargs = retry_kwargs_fn(kwargs, ctx)
+            else:
+                retry_kwargs = kwargs
+
+            try:
+                return self.action.run(**retry_kwargs)
+            except Exception as e:
+                ctx['error'] = e
+                raise e
+            finally:
+                ctx['idx'] = ctx.idx + 1
+
         if not self.action:
             return
-
-        timeout_in_sec = kwargs.get('timeout')
         if not timeout_in_sec:
-            return self.action.run(**kwargs)
+            return run_without_timeout()
 
         @timeout(timeout_in_sec)
         def run_with_timeout():
-            return self.action.run(**kwargs)
+            return run_without_timeout()
 
         return run_with_timeout()
 

--- a/src/cicd/ios/runner/xcodebuild/test.py
+++ b/src/cicd/ios/runner/xcodebuild/test.py
@@ -1,10 +1,19 @@
 from functools import cached_property
 
 from cicd.ios.runner.base import Runner
-from cicd.ios.xcodebuild.action import XCBTestAction
+from cicd.ios.xcodebuild.action import TestError, XCBTestAction
 
 
 class XCBTestRunner(Runner):
     @cached_property
     def action(self):
         return XCBTestAction()
+
+    def run(self, **kwargs):
+        def retry_kwargs_fn(kwargs: dict, ctx: Runner.RetryContext):
+            if isinstance(ctx.error, TestError):
+                kwargs['only_testing'] = ctx.error.xcresult.failed_tests
+            return kwargs
+
+        kwargs['retry_kwargs_fn'] = retry_kwargs_fn
+        return super().run(**kwargs)

--- a/src/cicd/ios/test.py
+++ b/src/cicd/ios/test.py
@@ -10,6 +10,7 @@ class TestJob(TestMixin):
 
 
 @click.command()
+@click.option('--retries', type=int, help='Number of test retries')
 @click.option('--only-testing', multiple=True, help='Run only these tests')
 @click.option('--test-without-building', is_flag=True, help='Test without building')
 @click.option('--cocoapods', is_flag=True, help='Run pod install beforehand')


### PR DESCRIPTION
1. Implement test retries.
2. Update integration tests to simulate the scenario in which the test fails in the 1st run and succeeds in the 2nd run.