### PR TITLE
FEAT: CodeSign (certs & profiles)

### DIFF
--- a/src/cicd/core/security/keychain.py
+++ b/src/cicd/core/security/keychain.py
@@ -1,0 +1,63 @@
+import typing as t
+from pathlib import Path
+
+from cicd.core.logger import logger
+from cicd.core.utils.sh import sh
+
+
+class Keychain:
+    def __init__(self, **kwargs) -> None:
+        self.name: str = kwargs.get('name') or 'cicd'
+        self.password: str = kwargs.get('password') or ''
+
+    def prepare(self):
+        logger.info(f'Prepare keychain: {self.name}')
+        try:
+            self.delete()
+        except:
+            pass
+        self.create()
+        self.add_to_user_search_list()
+        self.unlock()
+        return self
+
+    def __enter__(self):
+        return self.prepare()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.delete()
+
+    def create(self):
+        sh.exec(f'security create-keychain -p {sh.quote(self.password)} {self.name}')
+
+    def delete(self):
+        sh.exec(f'security delete-keychain {self.name}')
+
+    def unlock(self):
+        sh.exec(f'security unlock-keychain -p {sh.quote(self.password)} {self.name}')
+
+    def user_search_list(self) -> t.List[str]:
+        output = sh.exec(f'security list-keychain -d user', capture_output=True)
+        return [line.strip().strip('"') for line in output.split('\n')]
+
+    def add_to_user_search_list(self):
+        current = self.user_search_list()
+        cmd = 'security list-keychain -d user -s {} {}'.format(
+            ' '.join(sh.quote(x) for x in current), self.name
+        )
+        sh.exec(cmd)
+
+    def import_cert(
+        self,
+        path: t.Union[str, Path],
+        password: t.Union[str, None] = None,
+        whitelisted_apps: t.Optional[t.List[str]] = None,
+    ):
+        cmd = 'security import {} -P {} -k {}'.format(
+            sh.quote(path),
+            sh.quote(password or ''),
+            self.name,
+        )
+        for app in whitelisted_apps or []:
+            cmd += f' -T {sh.quote(app)}'
+        sh.exec(cmd)

--- a/src/cicd/core/typing.py
+++ b/src/cicd/core/typing.py
@@ -1,0 +1,4 @@
+import typing as t
+from pathlib import Path
+
+StrPath = t.Union[str, Path]

--- a/src/cicd/core/utils/file.py
+++ b/src/cicd/core/utils/file.py
@@ -1,11 +1,10 @@
 import os
 import shutil
 import tempfile
-import typing as t
 from contextlib import contextmanager
 from pathlib import Path
 
-StrPath = t.Union[str, Path]
+from cicd.core.typing import StrPath
 
 
 class FileUtils:

--- a/src/cicd/ios/cli.py
+++ b/src/cicd/ios/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from cicd.core._cli.opts import Opts
+from cicd.ios.codesign.cli import main as codesign
 from cicd.ios.mixin.mono import MonoMixin as Mixin
 
 opts = Opts(
@@ -104,6 +105,9 @@ def archive(**kwargs):
 @opts.use('timeout', 'derived_data_path')
 def cov(**kwargs):
     Mixin(**kwargs).start_parsing_cov()
+
+
+main.add_command(codesign, name='codesign')
 
 
 if __name__ == '__main__':

--- a/src/cicd/ios/codesign/cert.py
+++ b/src/cicd/ios/codesign/cert.py
@@ -1,0 +1,18 @@
+import typing as t
+
+from cicd.core.logger import logger
+from cicd.core.typing import StrPath
+
+
+class Certificate:
+    def __init__(self, path: StrPath, password: t.Optional[str] = None) -> None:
+        self.path = path
+        self.password = password or ''
+
+    def install(self, keychain, whitelisted_apps):
+        logger.debug(f'Install certificate: {self.path}')
+        keychain.import_cert(
+            path=self.path,
+            password=self.password,
+            whitelisted_apps=whitelisted_apps,
+        )

--- a/src/cicd/ios/codesign/cli.py
+++ b/src/cicd/ios/codesign/cli.py
@@ -1,0 +1,24 @@
+import click
+
+from .codesign import CodeSign
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.command
+@click.option('--dir', required=True, help='Dir containing certificates and profiles')
+@click.option('--cert-password', help='Certificate password')
+def prepare(**kwargs):
+    CodeSign(**kwargs).prepare()
+
+
+@main.command
+def cleanup(**kwargs):
+    CodeSign(**kwargs).cleanup()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/cicd/ios/codesign/codesign.py
+++ b/src/cicd/ios/codesign/codesign.py
@@ -1,0 +1,42 @@
+import typing as t
+from pathlib import Path
+
+from cicd.core.security.keychain import Keychain
+
+from .cert import Certificate
+from .profile import ProvisioningProfile
+
+
+class CodeSign:
+    def __init__(self, **kwargs) -> None:
+        dir = kwargs.get('dir')
+        self.dir = Path(dir).expanduser() if dir else None
+        self.keychain = Keychain(
+            name=kwargs.get('keychain_name'),
+            password=kwargs.get('keychain_password'),
+        )
+        self.cert_password = kwargs.get('cert_password')
+        self.profiles: t.List[ProvisioningProfile] = []
+        self.certs: t.List[Certificate] = []
+
+    def resolve_profiles_and_certs(self):
+        self.profiles = [
+            ProvisioningProfile(p) for p in self.dir.glob('**/*.mobileprovision')
+        ]
+        self.certs = [
+            Certificate(p, self.cert_password) for p in self.dir.glob('**/*.p12')
+        ]
+
+    def prepare(self):
+        self.resolve_profiles_and_certs()
+        self.keychain.prepare()
+        for profile in self.profiles:
+            profile.install()
+        for cert in self.certs:
+            cert.install(keychain=self.keychain, whitelisted_apps=['/usr/bin/codesign'])
+
+    def cleanup(self):
+        try:
+            self.keychain.delete()
+        except:
+            pass

--- a/src/cicd/ios/codesign/profile.py
+++ b/src/cicd/ios/codesign/profile.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from cicd.core.logger import logger
+from cicd.core.typing import StrPath
+from cicd.core.utils.file import FileUtils
+
+
+class ProvisioningProfile:
+    def __init__(self, path: StrPath) -> None:
+        self.path = path
+        self.profiles_dir = Path(
+            '~/Library/MobileDevice/Provisioning Profiles'
+        ).expanduser()
+
+    def install(self):
+        logger.debug(f'Install profile: {self.path}')
+        FileUtils.copy(self.path, self.profiles_dir)


### PR DESCRIPTION
CLI to prepare/cleanup codesign:

```sh
# DIR: directory containing certificates and provisioning profiles
$ cicd ios codesign prepare --dir <DIR> --cert-password foo

$ cicd ios codesign cleanup
```