### PR TITLE
FEAT: CLI to bump version/build number

### DIFF
--- a/src/cicd/core/version.py
+++ b/src/cicd/core/version.py
@@ -1,0 +1,11 @@
+from packaging import version
+
+__all__ = ['Version']
+
+
+class Version(version.Version):
+    def next(self, component: str = 'micro') -> 'Version':
+        idx = {'major': 0, 'minor': 1, 'micro': 2}.get(component)
+        parts = list(self.release)
+        parts[idx] += 1
+        return Version('.'.join(str(x) for x in parts))

--- a/src/cicd/ios/cli.py
+++ b/src/cicd/ios/cli.py
@@ -110,6 +110,21 @@ def cov(**kwargs):
     Mixin(**kwargs).start_parsing_cov()
 
 
+@main.command
+@click.option('--version', type=str, help='Bump version to this one')
+@click.option('--version-next', is_flag=True, help='Bump version to the next one')
+@click.option('--build-number', type=int, help='Bump build number to this one')
+@click.option(
+    '--build-number-next', is_flag=True, help='Bump build number to the next one'
+)
+def bump(**kwargs):
+    mixin = Mixin(**kwargs)
+    if kwargs.get('version') or kwargs.get('version_next'):
+        mixin.bump_version(to_value=kwargs.get('version'))
+    if kwargs.get('build_number') or kwargs.get('build_number_next'):
+        mixin.bump_build_number(to_value=kwargs.get('build_number'))
+
+
 main.add_command(codesign, name='codesign')
 
 

--- a/src/cicd/ios/mixin/base_ios.py
+++ b/src/cicd/ios/mixin/base_ios.py
@@ -2,12 +2,14 @@ from cicd.core.mixin.core import CoreMixin
 
 from .cocoapods import CocoaPodsMixin
 from .simulator import SimulatorMixin
+from .version import VersionMixin
 
 
 class BaseIOSMixin(
     CoreMixin,
     SimulatorMixin,
     CocoaPodsMixin,
+    VersionMixin,
 ):
     def __init__(self, **kwargs) -> None:
         self.kwargs = kwargs

--- a/src/cicd/ios/mixin/version.py
+++ b/src/cicd/ios/mixin/version.py
@@ -1,0 +1,40 @@
+import re
+import typing as t
+
+from cicd.core.logger import logger
+from cicd.core.version import Version
+
+from .metadata import MetadataMixin
+
+T = t.TypeVar('T')
+
+
+class VersionMixin(MetadataMixin):
+    def _from_build_settings(self, key, dtype: t.Type[T]) -> T:
+        content = self.metadata.pbxproj_path.read_text()
+        return max(dtype(x) for x in re.findall(f'\\b{key} = (.*);', content))
+
+    def _update_build_settings(self, key, value):
+        content = self.metadata.pbxproj_path.read_text()
+        content = re.sub(f'\\b{key} = (.*);', f'{key} = {value};', content)
+        self.metadata.pbxproj_path.write_text(content)
+
+    @property
+    def version(self) -> Version:
+        return self._from_build_settings(key='MARKETING_VERSION', dtype=Version)
+
+    @property
+    def build_number(self) -> int:
+        return self._from_build_settings(key='CURRENT_PROJECT_VERSION', dtype=int)
+
+    def bump_version(self, to_value: t.Optional[str] = None) -> Version:
+        to_value = Version(to_value) if to_value else self.version.next()
+        logger.info(f'Bump version to: {to_value}')
+        self._update_build_settings(key='MARKETING_VERSION', value=str(to_value))
+        return to_value
+
+    def bump_build_number(self, to_value: t.Optional[int] = None) -> int:
+        to_value = to_value or (self.build_number + 1)
+        logger.info(f'Bump build number to: {to_value}')
+        self._update_build_settings(key='CURRENT_PROJECT_VERSION', value=to_value)
+        return to_value

--- a/src/cicd/ios/project/metadata.py
+++ b/src/cicd/ios/project/metadata.py
@@ -25,6 +25,10 @@ class Metadata:
             logger.warning('Multiple xcode projects are detected')
         return paths[0]
 
+    @property
+    def pbxproj_path(self) -> Path:
+        return self.xcodeproj_path / 'project.pbxproj'
+
     @cached_property
     def xcworkspace_path(self) -> t.Optional[Path]:
         paths = list(self.workdir.glob('*.xcworkspace'))

--- a/tests/core/test_version.py
+++ b/tests/core/test_version.py
@@ -1,0 +1,17 @@
+import pytest
+
+from cicd.core.version import Version
+
+
+@pytest.mark.parametrize(
+    'base, component, expected',
+    [
+        ('0.0.1', 'major', '1.0.1'),
+        ('0.0.1', 'minor', '0.1.1'),
+        ('0.0.1', 'micro', '0.0.2'),
+    ],
+)
+def test_version_next(base, component, expected):
+    next_version = Version(base).next(component)
+    assert isinstance(next_version, Version)
+    assert str(next_version) == expected

--- a/tests/ios/mixin/test_version_mixin.py
+++ b/tests/ios/mixin/test_version_mixin.py
@@ -1,0 +1,45 @@
+import pytest
+
+from cicd.core.version import Version
+from cicd.ios.mixin.version import VersionMixin
+
+
+def gen_pbxproj_content(version: str, build_number: int) -> str:
+    return f"""
+PRODUCT_NAME = EX;
+MARKETING_VERSION = {version};
+CURRENT_PROJECT_VERSION = {build_number};
+SWIFT_VERSION = 5.0;
+"""
+
+
+@pytest.fixture
+def pbxproj_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / 'EX.xcodeproj' / 'project.pbxproj'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(gen_pbxproj_content(version='0.0.1', build_number=1))
+    return path
+
+
+@pytest.fixture
+def sut(pbxproj_path):
+    return VersionMixin()
+
+
+def test_version_read(sut: VersionMixin):
+    assert sut.version == Version('0.0.1')
+    assert sut.build_number == 1
+
+
+def test_version_bump(sut: VersionMixin, pbxproj_path):
+    assert sut.bump_version() == Version('0.0.2')
+    assert sut.bump_build_number() == 2
+    assert pbxproj_path.read_text() == gen_pbxproj_content(
+        version='0.0.2', build_number=2
+    )
+    assert sut.bump_version('0.0.9') == Version('0.0.9')
+    assert sut.bump_build_number(9) == 9
+    assert pbxproj_path.read_text() == gen_pbxproj_content(
+        version='0.0.9', build_number=9
+    )


### PR DESCRIPTION
CLI to bump version/build number
```sh
$ cicd ios bump --version 0.0.2 --build-number-next
```