### PR TITLE
FEAT: Test retries - Update default `retry_kwargs_fn` to retry only failed tests

### DIFF
--- a/scripts/integration_test_ios.sh
+++ b/scripts/integration_test_ios.sh
@@ -19,7 +19,7 @@ if [[ "${ONLY_TESTING}" == "EXTests" ]]; then
 fi
 
 function _exec_build() {
-    python3 -m cicd.ios.cli build \
+    cicd ios build \
         ${common_args[@]} \
         --build-for-testing
 }
@@ -35,7 +35,7 @@ function _exec_test() {
             --shard-idx ${SHARD_IDX:-0}
         )
     fi
-    python3 -m cicd.ios.cli test \
+    cicd ios test \
         ${common_args[@]} \
         ${args[@]} \
         --retries 1 \
@@ -43,7 +43,7 @@ function _exec_test() {
 }
 
 function _exec_cov() {
-    python3 -m cicd.ios.cli cov \
+    cicd ios cov \
         ${common_args[@]} \
         --config .cov.yml \
         --export .artifacts/cov/cov.json

--- a/src/cicd/ios/mixin/test.py
+++ b/src/cicd/ios/mixin/test.py
@@ -1,4 +1,4 @@
-from cicd.ios.actions.xcodebuild import XCBTestAction
+from cicd.ios.actions.xcodebuild import TestError, XCBTestAction
 
 from .base_ios import BaseIOSMixin
 from .test_sharding import TestShardingMixin
@@ -6,7 +6,14 @@ from .test_sharding import TestShardingMixin
 
 class TestMixin(BaseIOSMixin, TestShardingMixin):
     def start_testing(self):
+        def retry_kwargs_fn(kwargs, ctx):
+            if isinstance(ctx.error, TestError):
+                kwargs['only_testing'] = ctx.error.xcresult.failed_tests
+            return kwargs
+
         shard = self.get_test_shard(**self.kwargs)
         if shard:
             self.kwargs['only_testing'] = shard
+        if 'retry_kwargs_fn' not in self.kwargs:
+            self.kwargs['retry_kwargs_fn'] = retry_kwargs_fn
         self.runner_exec(action_cls=XCBTestAction)

--- a/src/cicd/ios/runner/base.py
+++ b/src/cicd/ios/runner/base.py
@@ -30,6 +30,9 @@ class Runner:
         def error(self) -> t.Optional[Exception]:
             return self.get('error')
 
+        def copy(self) -> 'Runner.RetryContext':
+            return Runner.RetryContext(super().copy())
+
     def run(self, action_cls: t.Type[Action], **kwargs):
         timeout_in_sec = kwargs.get('timeout')
         tries = (kwargs.get('retries') or 0) + 1


### PR DESCRIPTION
Update default `retry_kwargs_fn` to retry only failed tests